### PR TITLE
Add Capybara >= 2.4.0 gem dependency for RSpec feature specs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem 'devise-guests', '~> 0.5'
 group :development, :test do
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
+  gem 'capybara', '>= 2.4.0'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,13 @@ GEM
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (1.17.0)
+    capybara (2.15.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     carrierwave (1.1.0)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -437,6 +444,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_magick (4.8.0)
+    mini_mime (0.1.3)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     mono_logger (1.1.0)
@@ -725,12 +733,15 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xml-simple (1.1.5)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  capybara (>= 2.4.0)
   coffee-rails (~> 4.2)
   database_cleaner
   devise


### PR DESCRIPTION
See: https://relishapp.com/rspec/rspec-rails/docs/feature-specs/feature-spec

Currently, "Create a Work a logged in user" specs in
spec/features/create_work_spec.rb are pending due to
this dependency.