### PR TITLE
Remove deprecated "curation_concerns_embargo_management" from routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes
-  curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
Currently, this results in the deprecation warning:

    DEPRECATION WARNING: #curation_concerns_embargo_management is deprecated and has no effect. It will be removed in Hyrax 3.0. (called from block in <top (required)> at /vagrant/scholrax/config/routes.rb:22)

You can see the associated Hyrax commit here: https://github.com/samvera/hyrax/commit/5cee68f67f77089e350f91135b68297d336406dd

Embargoes now seem to be included by default, so no additional reconfiguration appears to be necessary. I tested this by running with just this change in my dev environment and creating an embargoed work, which then still showed up at the `/embargoes` route for my admin user.