### PR TITLE
Ddr 950 oai pmh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'hyrax', '2.0.0.beta1'
 
-gem 'blacklight_oai_provider', :git => 'https://github.com/osulibraries/blacklight_oai_provider.git'
-
 group :development, :test do
   gem 'database_cleaner'
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ group :production do
   gem 'pg'
   gem 'therubyracer', platforms: :ruby
 end
+
+gem 'blacklight_oai_provider', git: 'https://github.com/osulibraries/blacklight_oai_provider.git', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,7 @@
 GIT
-<<<<<<< Updated upstream
-  remote: https://github.com/osulibraries/blacklight_oai_provider.git
-  revision: a6a0b9359e179445b633e16856f00c0604c89f57
-=======
-  remote: https://github.com/aaron-collier/sword.git
-  revision: df35762c481c1ede27c976602ae9d1997a2b846e
-  branch: master
-  specs:
-    sword (0.1.0)
-      rails (~> 5.0.3)
-
-GIT
   remote: https://github.com/osulibraries/blacklight_oai_provider.git
   revision: a6a0b9359e179445b633e16856f00c0604c89f57
   branch: master
->>>>>>> Stashed changes
   specs:
     blacklight_oai_provider (1.4.1)
       blacklight (>= 6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1210,7 +1210,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
-  sword!
   therubyracer
   turbolinks (~> 5)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,20 @@
 GIT
+<<<<<<< Updated upstream
   remote: https://github.com/osulibraries/blacklight_oai_provider.git
   revision: a6a0b9359e179445b633e16856f00c0604c89f57
+=======
+  remote: https://github.com/aaron-collier/sword.git
+  revision: df35762c481c1ede27c976602ae9d1997a2b846e
+  branch: master
+  specs:
+    sword (0.1.0)
+      rails (~> 5.0.3)
+
+GIT
+  remote: https://github.com/osulibraries/blacklight_oai_provider.git
+  revision: a6a0b9359e179445b633e16856f00c0604c89f57
+  branch: master
+>>>>>>> Stashed changes
   specs:
     blacklight_oai_provider (1.4.1)
       blacklight (>= 6.1)
@@ -1209,6 +1223,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  sword!
   therubyracer
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,6 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
+  include BlacklightOaiProvider::CatalogControllerBehavior
   include Hydra::Controller::ControllerBehavior
   include BlacklightOaiProvider::CatalogControllerBehavior
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,7 +26,15 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
-  # Do content negotiation for AF models. 
+  field_semantics.merge!(
+    creator:     'creator_tesim',
+    date:        'date_created_tesim',
+    description: 'description_tesim',
+    rights:      'rights_statement_tesim',
+    title:       'title_tesim',
+    type:        'resource_type_tesim')
+
+  # Do content negotiation for AF models.
 
   use_extension( Hydra::ContentNegotiation )
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,7 +30,9 @@ class SolrDocument
     creator:     'creator_tesim',
     date:        'date_created_tesim',
     description: 'description_tesim',
+    language:    'language_tesim',
     rights:      'rights_statement_tesim',
+    subject:     'subject_tesim',
     title:       'title_tesim',
     type:        'resource_type_tesim')
 


### PR DESCRIPTION
See notes on https://duldev.atlassian.net/browse/DDR-950. Should fully enable OAI on Scholrax. There may be some additional metadata mappings we want. I just filled in the fields they had stubs for.

(re-issued because there was an error in the merged Gemfile)