### PR TITLE
Lock Solr version to 6.6.1 in .solr_wrapper

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 6.6.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:


### PR DESCRIPTION
Solr 7 released on September 19th, but Hyrax isn't yet Solr 7-compliant.

See upstream: https://github.com/samvera/hyrax/commit/881490b9981d444434f8c93b59340d0a0b368871

Without this, you get something like the following error for `bundle exec rake ci` and on all automated Travis builds:
```
solr-7.0.0.zip: |====================================================================================================================================================================================================================| 100% (Time: 00:00:07 )
solr-7.0.0.zip.md5: |================================================================================================================================================================================================================| 100% (Time: 00:00:00 )
rake aborted!
Failed to execute solr create:
Copying configuration to new core instance directory:
/vagrant/scholrax/tmp/solr-test/server/solr/hydra-test

Creating new core 'hydra-test' using command:
http://localhost:8985/solr/admin/cores?action=CREATE&name=hydra-test&instanceDir=hydra-test


ERROR: Error CREATEing SolrCore 'hydra-test': Unable to create core [hydra-test] Caused by: Setting default operator in schema (solrQueryParser/@defaultOperator) not supported

. Further information may be available in tmp/solr-test/logs
/var/lib/gems/2.3.0/gems/solr_wrapper-1.1.0/lib/solr_wrapper/instance.rb:322:in `exec'
/var/lib/gems/2.3.0/gems/solr_wrapper-1.1.0/lib/solr_wrapper/instance.rb:159:in `create'
/var/lib/gems/2.3.0/gems/solr_wrapper-1.1.0/lib/solr_wrapper/instance.rb:216:in `with_collection'
/var/lib/gems/2.3.0/gems/active-fedora-11.4.0/lib/active_fedora/rake_support.rb:26:in `block in with_server'
/var/lib/gems/2.3.0/gems/solr_wrapper-1.1.0/lib/solr_wrapper/instance.rb:65:in `wrap'
/var/lib/gems/2.3.0/gems/solr_wrapper-1.1.0/lib/solr_wrapper.rb:43:in `wrap'
/var/lib/gems/2.3.0/gems/active-fedora-11.4.0/lib/active_fedora/rake_support.rb:17:in `with_server'
/vagrant/scholrax/rakefile:11:in `block in <top (required)>'
/var/lib/gems/2.3.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => ci
(See full trace by running task with --trace)
```